### PR TITLE
Hotfix ranking movement indicator

### DIFF
--- a/endpoints/get_ranking.py
+++ b/endpoints/get_ranking.py
@@ -41,9 +41,9 @@ def get_ranking():
 
             before_ranking = before_rankings_indexed_by_id[current_ranking.uiID1]
 
-            if current_rank > before_ranking.Rank:
+            if current_rank < before_ranking.Rank:
                 current_ranking.MovementType = MovementType.UP
-            elif current_rank < before_ranking.Rank:
+            elif current_rank > before_ranking.Rank:
                 current_ranking.MovementType = MovementType.DOWN
             else:
                 current_ranking.MovementType = MovementType.UNCHANGED


### PR DESCRIPTION
Closes #6 

### Fixes
Swapped `<` and `>` here:
- https://github.com/devinlizardi/astro-rankings/blob/e23b0e94a34d66d36401428d9bc591cbceaf6016/endpoints/get_ranking.py#L44
- https://github.com/devinlizardi/astro-rankings/blob/e23b0e94a34d66d36401428d9bc591cbceaf6016/endpoints/get_ranking.py#L46

### Explanation
I wrote this code with the false understanding that a higher ranking meant a user moved up the table and vice-versa, but this is not the case. I corrected the code accordingly.
